### PR TITLE
DPE-60 postgresql patroni container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu/postgres:12-20.04_beta
+
+RUN echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
+    && apt-get update -y \
+    # Install Patroni and its dependencies.
+    && apt-cache depends patroni | sed -n -e 's/.* Depends: \(python3-.\+\)$/\1/p' \
+            | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes)' \
+            | xargs apt-get install -y git python3-pip python3-wheel \
+    && pip3 install setuptools \
+    && pip3 install 'git+https://github.com/zalando/patroni.git@v2.1.2#egg=patroni[kubernetes]' \
+    # Clean up.
+    && apt-get remove -y git python3-pip python3-wheel \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /root/.cache
+
+# Expose PostgreSQL and Patroni REST API ports.
+EXPOSE 5432 8008

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,10 @@ EXPOSE 5432 8008
 # Default environment variables.
 ENV PATRONI_SUPERUSER_USERNAME=postgres
 ENV PATRONI_REPLICATION_USERNAME=replication
+
+# User which should own Patroni and PostgreSQL processes.
+USER postgres
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,6 @@ RUN echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/a
 
 # Expose PostgreSQL and Patroni REST API ports.
 EXPOSE 5432 8008
+# Default environment variables.
+ENV PATRONI_SUPERUSER_USERNAME=postgres
+ENV PATRONI_REPLICATION_USERNAME=replication

--- a/README.md
+++ b/README.md
@@ -1,3 +1,78 @@
-# postgresql-patroni-container
+# PostgreSQL + Patroni Container
 
-A docker container, containing the PostgreSQL and Patroni. Built for use in the PostgreSQL k8s charm: https://github.com/canonical/postgresql-k8s-operator
+This docker container image bundles [PostgreSQL](https://www.postgresql.org/about/) database and [Patroni](https://github.com/zalando/patroni) (a template for PostgreSQL HA).
+
+Built for use in the [PostgreSQL k8s charm](https://github.com/canonical/postgresql-k8s-operator).
+
+Currently it uses [Postgres 12.4 on Ubuntu 20.04 LTS](https://hub.docker.com/r/ubuntu/postgres/) as the base image and adds Patroni v2.1.2 on top of it.
+
+## Usage
+
+This container image requires a configuration file for Patroni and also some environment variables. They are explained in the following subsections.
+
+Once they are all set and the image is present in a registry accessible on your cluster or published along with the charm, the charm can execute the following command to start Patroni (which starts and manages PostgreSQL process lifecycle):
+
+```sh
+/usr/bin/python3 /usr/local/bin/patroni /var/lib/postgresql/data/patroni.yml # use the path where the charm pushed the configuration file
+```
+
+### Patroni configuration file
+
+The k8s charm using this container image should push a Patroni [configuration file](https://patroni.readthedocs.io/en/latest/SETTINGS.html) with the following layout (replacing the `{{ pod_ip }}` variable with the pod IP address):
+
+```yaml
+bootstrap:
+  dcs:
+    postgresql:
+      use_pg_rewind: true
+  initdb:
+  - auth-host: md5
+  - auth-local: trust
+  - encoding: UTF8
+  - locale: en_US.UTF-8
+  - data-checksums
+  pg_hba:
+  - host all all 0.0.0.0/0 md5
+  - host replication replication {{ pod_ip }}/16 md5
+bypass_api_service: true
+log:
+  dir: /var/log/postgresql
+restapi:
+  connect_address: '{{ pod_ip }}:8008'
+  listen: 0.0.0.0:8008
+pod_ip: '{{ pod_ip }}'
+postgresql:
+  connect_address: '{{ pod_ip }}:5432'
+  custom_conf: /var/lib/postgresql/data/postgresql-k8s-operator.conf
+  data_dir: /var/lib/postgresql/data/pgdata
+  listen: 0.0.0.0:5432
+  pgpass: /tmp/pgpass
+use_endpoints: true
+```
+
+The charm can also change the values of these settings (but these ones are good defaults based on [Patroni k8s example](https://github.com/zalando/patroni/tree/master/kubernetes)) or choose different paths for the logs directory, data directory and custom `postgresql.conf` file based on how it's setting the paths in its code.
+
+### Environment variables
+
+Some additional [environment variables](https://patroni.readthedocs.io/en/latest/ENVIRONMENT.html) are required to properly start and run both Patroni and PostgreSQL:
+
+- `PATRONI_KUBERNETES_LABELS`
+  - Labels applied to the created pods and which are used by Patroni to find the members of a cluster and replicate the data.
+- `PATRONI_KUBERNETES_NAMESPACE`
+  - Namespace where the pods are created.
+- `PATRONI_NAME`
+  - Name of the member in the cluster (for example, the pod name, such as postgresql-k8s-0).
+- `PATRONI_SCOPE`
+  - Cluster name (can be the name of the juju deployment).
+- `PATRONI_REPLICATION_USERNAME`
+  - Username Patroni will use to manage PostgreSQL replication.
+  - Default = replication
+- `PATRONI_REPLICATION_PASSWORD`
+  - Password for Patroni replication user.
+- `PATRONI_SUPERUSER_USERNAME`
+  - Username that is used to run `init db` in the PostgreSQL bootstrap process.
+  - Default = postgres
+- `PATRONI_SUPERUSER_PASSWORD`
+  - Password for PostgreSQL superuser.
+
+These variables can also be informed in the configuration file. They are listed separately from the configuration file in this README because it makes it easier to unit test the current PostgreSQL k8s charm.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Some additional [environment variables](https://patroni.readthedocs.io/en/latest
   - Labels applied to the created pods and which are used by Patroni to find the members of a cluster and replicate the data.
 - `PATRONI_KUBERNETES_NAMESPACE`
   - Namespace where the pods are created.
+- `PATRONI_KUBERNETES_POD_IP`
+  - IP of the current pod (this variable is required only when deploying the image directly to a cluster i.e. not in a charm which replaces the pod IP in the `patroni.yml` file).
 - `PATRONI_NAME`
   - Name of the member in the cluster (for example, the pod name, such as postgresql-k8s-0).
 - `PATRONI_SCOPE`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+cat > /var/lib/postgresql/data/patroni.yml <<__EOF__
+bootstrap:
+  dcs:
+    postgresql:
+      use_pg_rewind: true
+  initdb:
+  - auth-host: md5
+  - auth-local: trust
+  - encoding: UTF8
+  - locale: en_US.UTF-8
+  - data-checksums
+  pg_hba:
+  - host all all 0.0.0.0/0 md5
+  - host replication ${PATRONI_REPLICATION_USERNAME} ${PATRONI_KUBERNETES_POD_IP}/16 md5
+restapi:
+  connect_address: '${PATRONI_KUBERNETES_POD_IP}:8008'
+  listen: 0.0.0.0:8008
+pod_ip: '${PATRONI_KUBERNETES_POD_IP}'
+postgresql:
+  connect_address: '${PATRONI_KUBERNETES_POD_IP}:5432'
+  data_dir: /var/lib/postgresql/data/pgdata
+  listen: 0.0.0.0:5432
+use_endpoints: true
+__EOF__
+
+/usr/bin/python3 /usr/local/bin/patroni /var/lib/postgresql/data/patroni.yml


### PR DESCRIPTION
This PR adds a docker image containing PostgreSQL and Patroni.

As this image is intended (at least so far) to be used only in the PostgreSQL k8s charm, there is no configuration file or entry point being added to the image. The charm will handle both (so we don't duplicate them in in this docker image).